### PR TITLE
Adds support for JSON parsing of log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ To configure this in fluentd:
   loggly_token <your_loggly_token>
   loggly_tag <your_loggly_tag>
   loggly_hostname "#{ENV['HOST']}"
+  parse_json true
 </match>
 ```
 
+Also, if you set `parse_json` to true, as is shown in the example above, then the plugin will attempt to parse the `message` field from each fluentd record.
 
 ### Advanced Configuration
 This plugin inherits a few useful config parameters from Fluent's `BufferedOutput` class.

--- a/fluent-plugin-loggly-syslog.gemspec
+++ b/fluent-plugin-loggly-syslog.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-loggly-syslog"
-  spec.version       = "0.0.2"
+  spec.version       = "0.0.3"
   spec.authors       = ["Chris Rust"]
   spec.email         = ["chris.rust@solarwinds.com"]
 

--- a/lib/fluent/plugin/out_loggly_syslog.rb
+++ b/lib/fluent/plugin/out_loggly_syslog.rb
@@ -13,6 +13,7 @@ module Fluent
     config_param :loggly_host, :string, default: 'logs-01.loggly.com'
     config_param :loggly_port, :integer, default: 6514
     config_param :discard_unannotated_pod_logs, :bool, default: false
+    config_param :parse_json, :bool, default: false
     # overriding default flush_interval (60 sec) from Fluent::BufferedOutput
     config_param :flush_interval, :time, default: 1
 
@@ -93,6 +94,14 @@ module Fluent
       #   '<134>1 2018-05-10T21:11:58-05:00 mysite.com myapp procid msgid \
       #     [xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx@41058 tag="syslog"] \
       #     message'
+
+      if @parse_json
+        begin
+          parsed_message = JSON.parse(record.message)
+          record.message = parsed_message
+        rescue JSON::ParserError
+        end
+      end
 
       pri             = 134                                          # 134 is hardcoded facility local0 and severity info
       version         = 1                                            # Syslog Protocol v1


### PR DESCRIPTION
If a user sets `parse_json`  to true in their fluentd config, then the plugin will attempt to parse the `message` field from each fluentd record.

Addresses Issue #3 