### PR TITLE
Avoid all string comparisons that trigger implicit encoding expectations

### DIFF
--- a/fluent-plugin-loggly-syslog.gemspec
+++ b/fluent-plugin-loggly-syslog.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-loggly-syslog"
-  spec.version       = "0.0.4"
+  spec.version       = "0.0.5"
   spec.authors       = ["Chris Rust"]
   spec.email         = ["chris.rust@solarwinds.com"]
 
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fluentd", '>= 1.2', '< 2'
+  spec.add_dependency "yajl-ruby", '>= 1.3.1'
 
   spec.add_development_dependency "bundler", "~> 2.0.1"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
- Switch stdlib JSON.parse and to_json calls to Yajl library implementations, which treat all data as ASCII binary (same as fluentd)
- Switch from socket.puts to socket.write ([there was a !~ string comparison in puts](https://github.com/ruby/openssl/blob/v2.1.2/lib/openssl/buffering.rb#L412))
- Pad payload string with newline character `\n`, puts fn did this inherently whereas write fn does not  

Resolves issue https://github.com/solarwinds/fluent-plugin-loggly-syslog/issues/5